### PR TITLE
JBOSGI-510 StartLevelIntegrationTestCase fails on jdk1.7

### DIFF
--- a/core/src/test/java/org/jboss/osgi/framework/internal/StartLevelTestCase.java
+++ b/core/src/test/java/org/jboss/osgi/framework/internal/StartLevelTestCase.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.jboss.osgi.framework.internal.StartLevelPlugin;
 import org.jboss.osgi.testing.OSGiFrameworkTest;
 import org.jboss.osgi.testing.OSGiManifestBuilder;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -50,6 +49,7 @@ public class StartLevelTestCase extends OSGiFrameworkTest {
     @Test
     public void testStartLevel() throws Exception {
         StartLevel startLevel = getStartLevel();
+        int orgStartLevel = startLevel.getStartLevel();
         int orgInitialStartlevel = startLevel.getInitialBundleStartLevel();
         try {
             setTestExecutor(startLevel);
@@ -100,6 +100,7 @@ public class StartLevelTestCase extends OSGiFrameworkTest {
             }
         } finally {
             startLevel.setInitialBundleStartLevel(orgInitialStartlevel);
+            startLevel.setStartLevel(orgStartLevel);
         }
     }
 
@@ -108,6 +109,7 @@ public class StartLevelTestCase extends OSGiFrameworkTest {
         BundleContext sc = getFramework().getBundleContext();
         ServiceReference sref = sc.getServiceReference(StartLevel.class.getName());
         StartLevel sls = (StartLevel) sc.getService(sref);
+        int orgStartLevel = sls.getStartLevel();
         int orgInitialStartlevel = sls.getInitialBundleStartLevel();
         try {
             setTestExecutor(sls);
@@ -135,6 +137,7 @@ public class StartLevelTestCase extends OSGiFrameworkTest {
             }
         } finally {
             sls.setInitialBundleStartLevel(orgInitialStartlevel);
+            sls.setStartLevel(orgStartLevel);
         }
     }
 

--- a/itest/src/test/java/org/jboss/test/osgi/framework/startlevel/StartLevelIntegrationTestCase.java
+++ b/itest/src/test/java/org/jboss/test/osgi/framework/startlevel/StartLevelIntegrationTestCase.java
@@ -21,6 +21,11 @@
  */
 package org.jboss.test.osgi.framework.startlevel;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.InputStream;
+import java.util.Properties;
+
 import org.jboss.osgi.testing.OSGiFrameworkTest;
 import org.jboss.osgi.testing.OSGiManifestBuilder;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -37,14 +42,9 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.framework.launch.Framework;
 import org.osgi.service.startlevel.StartLevel;
 
-import java.io.InputStream;
-import java.util.Properties;
-
-import static org.junit.Assert.assertEquals;
-
 /**
  * Test start level.
- * 
+ *
  * @author thomas.diesler@jboss.com
  * @author <a href="david@redhat.com">David Bosschaert</a>
  * @since 29-Apr-2010
@@ -93,6 +93,7 @@ public class StartLevelIntegrationTestCase extends OSGiFrameworkTest {
 
     @Test
     public void testOrderedStop() throws Exception {
+        System.setProperty("LifecycleOrdering", "");
         JavaArchive archive1 = createTestBundle("b1.jar", org.jboss.test.osgi.framework.bundle.support.lifecycle1.Activator.class);
         JavaArchive archive2 = createTestBundle("b2.jar", org.jboss.test.osgi.framework.bundle.support.lifecycle2.Activator.class);
         JavaArchive archive3 = createTestBundle("b3.jar", org.jboss.test.osgi.framework.bundle.support.lifecycle3.Activator.class);
@@ -135,7 +136,7 @@ public class StartLevelIntegrationTestCase extends OSGiFrameworkTest {
         } finally {
             framework.stop();
             framework.waitForStop(2000);
-            
+
             synchronized ("LifecycleOrdering") {
                 assertEquals("start1start3start2stop2stop3stop1", System.getProperty("LifecycleOrdering"));
             }


### PR DESCRIPTION
This was caused by state left behind from another test which was exposed when the tests ran in a different order.
I found a similar issue in the StartLevelTestCase.
