### PR TITLE
Prevent a NPE from being thrown in HostBundleRevision while loading class

### DIFF
--- a/core/src/main/java/org/jboss/osgi/framework/internal/BundleStateRevision.java
+++ b/core/src/main/java/org/jboss/osgi/framework/internal/BundleStateRevision.java
@@ -130,7 +130,8 @@ abstract class BundleStateRevision extends AbstractBundleRevision {
                 Module module = moduleManager.loadModule(identifier);
                 moduleClassLoader = module.getClassLoader();
             } catch (ModuleLoadException ex) {
-                // ignore
+                // log the error
+                FrameworkLogger.LOGGER.debug("Failed to load module identifier " + identifier, ex);
             }
         }
         return moduleClassLoader;

--- a/core/src/main/java/org/jboss/osgi/framework/internal/HostBundleRevision.java
+++ b/core/src/main/java/org/jboss/osgi/framework/internal/HostBundleRevision.java
@@ -125,8 +125,11 @@ final class HostBundleRevision extends UserBundleRevision {
         if (getBundleState().ensureResolved(true) == false)
             throw MESSAGES.classNotFoundInRevision(className, this);
 
-        // Load the class through the module
+        // Load the class through the module classloader
         ModuleClassLoader loader = getModuleClassLoader();
+        if (loader == null) {
+            throw MESSAGES.classNotFoundInRevision(className, this);
+        }
         return loader.loadClass(className, true);
     }
 


### PR DESCRIPTION
The commit here prevents a NPE from happening while loading a class in HostBundleRevision. This was noticed in https://issues.jboss.org/browse/AS7-6016. Note that this isn't a solution to whatever is causing the class from being loaded, but this commit handles such failures better.
